### PR TITLE
docs: fix simple typo, automaticaly -> automatically

### DIFF
--- a/src/io/http/http_parser.c
+++ b/src/io/http/http_parser.c
@@ -1950,7 +1950,7 @@ reexecute:
             && parser->content_length != ULLONG_MAX);
 
         /* The difference between advancing content_length and p is because
-         * the latter will automaticaly advance on the next loop iteration.
+         * the latter will automatically advance on the next loop iteration.
          * Further, if content_length ends up at 0, we want to see the last
          * byte again for our message complete callback.
          */


### PR DESCRIPTION
There is a small typo in src/io/http/http_parser.c.

Should read `automatically` rather than `automaticaly`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md